### PR TITLE
anykernel: template updates + fixes (hammerhead)

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -6,7 +6,6 @@
 properties() {
 kernel.string=franco.Kernel by franciscofranco @ xda-developers
 do.devicecheck=1
-do.initd=0
 do.modules=0
 do.cleanup=1
 do.cleanuponabort=1
@@ -21,6 +20,12 @@ is_slot_device=0;
 ## AnyKernel methods (DO NOT CHANGE)
 # import patching functions/variables - see for reference
 . /tmp/anykernel/tools/ak2-core.sh;
+
+
+## AnyKernel file attributes
+# set permissions/ownership for included ramdisk files
+chmod -R 750 $ramdisk/*;
+chown -R root:root $ramdisk/*;
 
 
 ## AnyKernel install


### PR DESCRIPTION
- init.d is gone from AK2 for awhile now
- add back file attributes section now that mkbootfs is gone